### PR TITLE
ci(workflows): 优化package-agent构建与打包流程

### DIFF
--- a/.github/workflows/package-agent.yml
+++ b/.github/workflows/package-agent.yml
@@ -15,19 +15,16 @@ jobs:
       matrix:
         include:
           - name: windows-amd64
+            os: windows
             runner: windows-latest
-            shell: pwsh
-            release_cmd: .\scripts\release.ps1
             artifact: go/dist/htunnel-agent-windows-amd64.zip
           - name: macos-amd64
+            os: darwin
             runner: macos-13
-            shell: bash
-            release_cmd: ./scripts/release.sh
             artifact: go/dist/htunnel-agent-darwin-amd64.tar.gz
           - name: macos-arm64
+            os: darwin
             runner: macos-14
-            shell: bash
-            release_cmd: ./scripts/release.sh
             artifact: go/dist/htunnel-agent-darwin-arm64.tar.gz
 
     steps:
@@ -39,12 +36,21 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Package
-        shell: ${{ matrix.shell }}
+      - name: Package (Unix)
+        if: matrix.os != 'windows'
+        shell: bash
         working-directory: go
         env:
           INCLUDE_UI: "0"
-        run: ${{ matrix.release_cmd }}
+        run: ./scripts/release.sh
+
+      - name: Package (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        working-directory: go
+        env:
+          INCLUDE_UI: "0"
+        run: .\scripts\release.ps1
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- 统一matrix配置，替换原有name字段为os字段
- Windows平台使用windows-latest runner，Unix平台分别使用macos-13和macos-14
- 调整构建步骤，新增区分Windows与Unix的打包步骤
- Windows环境采用powershell执行release脚本，Unix环境采用bash执行
- 明确设置工作目录为go，统一环境变量INCLUDE_UI为0
- 删除无用的shell和release_cmd matrix变量，简化流程配置
- 保持上传artifact步骤不变，确保打包产物上传成功