### PR TITLE
feat(agent): 使用用户名密码自动登录获取 token 和路由配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ network:
 cd go
 go run ./cmd/htunnel-agent -config configs/agent.yaml
 ```
+  - 当 `auth.token` 为空时，agent 会使用 `auth.username/password` 调用 `/api/agent/login` 自动获取 token 和路由配置
 
 ## 目录
 - `go/configs/server.yaml`：服务端配置样例
@@ -200,11 +201,12 @@ server:
 auth:
   token: "<jwt-token>"
   username: "alice"
-  password: ""
+  password: "pass123"
   password_enc: "<encrypted-by-ui>"
 ```
 
 说明：桌面 UI 会把密码加密后写入 `password_enc`，不再持久化明文 `password`。
+当通过命令行直接启动 agent 时，若 `token` 为空，会尝试使用 `username/password` 自动登录获取 token。
 
 可用内置工具生成测试 token：
 ```bash

--- a/go/configs/agent.yaml
+++ b/go/configs/agent.yaml
@@ -6,11 +6,11 @@ server:
   connect_timeout_sec: 10
 
 auth:
-  # token can be auto refreshed by desktop UI on connect
+  # token can be refreshed by desktop UI or by agent startup login (when username/password are set)
   token: ""
   username: "alice"
-  # plaintext password is not recommended; desktop UI will persist encrypted password_enc
-  password: ""
+  # demo password; replace in production
+  password: "pass123"
   password_enc: ""
 
 agent:

--- a/go/internal/agent/agent.go
+++ b/go/internal/agent/agent.go
@@ -1,13 +1,19 @@
 package agent
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -24,8 +30,10 @@ func (s *Service) Run(ctx context.Context) error {
 	if s.cfg.Server.URL == "" {
 		return fmt.Errorf("server.url is required")
 	}
-	if s.cfg.Auth.Token == "" {
-		return fmt.Errorf("auth.token is required")
+	if strings.TrimSpace(s.cfg.Auth.Token) == "" {
+		if err := s.loginWithPassword(); err != nil {
+			return err
+		}
 	}
 	if err := s.cfg.EnsureRouteCommands(runtime.GOOS); err != nil {
 		return err
@@ -88,4 +96,103 @@ func WaitForSocket(ctx context.Context, addr string, timeout time.Duration) erro
 
 func init() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+}
+
+type loginResponse struct {
+	Token      string   `json:"token"`
+	AgentID    string   `json:"agent_id"`
+	WSURL      string   `json:"ws_url"`
+	RouteCIDRs []string `json:"route_cidrs"`
+}
+
+func (s *Service) loginWithPassword() error {
+	username := strings.TrimSpace(s.cfg.Auth.Username)
+	password := s.cfg.Auth.Password
+	if username == "" || strings.TrimSpace(password) == "" {
+		return fmt.Errorf("auth.token is required or set auth.username/auth.password for login")
+	}
+
+	baseURL := strings.TrimSpace(s.cfg.Server.BaseURL)
+	if baseURL == "" {
+		baseURL = inferHTTPBaseFromWSURL(s.cfg.Server.URL)
+	}
+	if baseURL == "" {
+		return fmt.Errorf("cannot infer server base url; set server.base_url")
+	}
+	loginURL := strings.TrimRight(baseURL, "/") + "/api/agent/login"
+
+	payload := map[string]string{
+		"username": username,
+		"password": password,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal login payload failed: %w", err)
+	}
+
+	timeout := time.Duration(s.cfg.Server.ConnectTimeoutSec) * time.Second
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	client := &http.Client{Timeout: timeout}
+	req, err := http.NewRequest(http.MethodPost, loginURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build login request failed: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("login request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("login failed status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var lr loginResponse
+	if err := json.Unmarshal(respBody, &lr); err != nil {
+		return fmt.Errorf("parse login response failed: %w", err)
+	}
+	if strings.TrimSpace(lr.Token) == "" {
+		return fmt.Errorf("login response missing token")
+	}
+
+	s.cfg.Auth.Token = strings.TrimSpace(lr.Token)
+	if strings.TrimSpace(lr.AgentID) != "" {
+		s.cfg.Agent.ID = strings.TrimSpace(lr.AgentID)
+	} else if s.cfg.Agent.ID == "" {
+		s.cfg.Agent.ID = username
+	}
+	if strings.TrimSpace(lr.WSURL) != "" {
+		s.cfg.Server.URL = strings.TrimSpace(lr.WSURL)
+	}
+	if len(lr.RouteCIDRs) > 0 {
+		s.cfg.Tun.RouteCIDRs = append([]string(nil), lr.RouteCIDRs...)
+	}
+	log.Printf("login success: user=%s ws=%s routes=%d", username, s.cfg.Server.URL, len(s.cfg.Tun.RouteCIDRs))
+	return nil
+}
+
+func inferHTTPBaseFromWSURL(wsURL string) string {
+	u, err := url.Parse(strings.TrimSpace(wsURL))
+	if err != nil {
+		return ""
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "ws":
+		u.Scheme = "http"
+	case "wss":
+		u.Scheme = "https"
+	case "http", "https":
+	default:
+		return ""
+	}
+	u.Path = ""
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return strings.TrimRight(u.String(), "/")
 }


### PR DESCRIPTION
- 当 auth.token 为空且设置了 auth.username/password 时，自动调用 /api/agent/login 接口登录
- 解析并更新登录返回的 token、agent_id、ws_url 和路由 CIDR 配置
- 新增根据 WS URL 推断 HTTP 基础 URL 的辅助函数
- 配置示例中增加 username 和 password 字段，支持自动登录
- README 中补充自动登录及 token 获取说明和示例指导
- 登录请求使用 JSON 格式，支持超时配置，增强登录逻辑健壮性