### PR TITLE
ci(workflows): 新增服务端镜像发布流水线

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -1,0 +1,48 @@
+name: Publish Server Image
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag (e.g. v2.1.0)"
+        required: true
+        type: string
+
+jobs:
+  docker:
+    name: Build & Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set Tag
+        id: vars
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: loongtall
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            loongtall/htunnel-server:${{ steps.vars.outputs.tag }}
+            loongtall/htunnel-server:latest

--- a/README.md
+++ b/README.md
@@ -259,3 +259,8 @@ GitHub Actions 已切换为 Go 流水线：`.github/workflows/go.yml`。
 - `darwin-arm64`
 
 当推送 `v*` tag（如 `v2.1.0`）时，会自动把上述产物作为附件上传到 GitHub Release。
+
+新增服务端镜像发布流水线：`.github/workflows/publish-server-image.yml`。
+- 触发：推送 `v*` tag 或手动触发
+- 产物：`loongtall/htunnel-server:<tagname>`（例如 `v2.1.0`）和 `loongtall/htunnel-server:latest`
+- 需要仓库 Secret：`DOCKERHUB_TOKEN`（Docker Hub Access Token）


### PR DESCRIPTION
- 增加 `.github/workflows/publish-server-image.yml` 文件
- 支持推送 `v*` 标签自动触发构建和发布
- 支持手动触发并指定镜像 tag
- 镜像推送到 Docker Hub，包含指定标签和 latest 标签
- 需要配置仓库 Secret `DOCKERHUB_TOKEN` 以进行身份验证
- 更新 README，添加服务端镜像发布流水线的使用说明