### PR TITLE
feat(server): 优化 WebSocket URL 解析及目标 IP 地址解析逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ docker run --rm -p 8082:8082 \
 - `auth.users`：客户端登录账号密码
 - `auth.users.<name>.route_cidrs`：该用户下发到客户端的网段（用于本地路由）
 - `network.vip_map`：虚拟 IP 到真实目标 IP 的映射  
+- `network.allow_direct_ip_fallback`：是否允许未命中 `vip_map` 时直连目标 IP（默认 `false`）
 
 示例：
 ```yaml
@@ -58,6 +59,7 @@ auth:
       route_cidrs:
         - "10.2.2.123/32"
 network:
+  allow_direct_ip_fallback: false
   vip_map:
     "10.2.2.123": "172.28.52.13"
 ```
@@ -171,10 +173,13 @@ cd go\dist\htunnel-agent-windows-amd64
 `go/configs/server.yaml`:
 ```yaml
 network:
+  allow_direct_ip_fallback: false
   vip_map:
     "10.2.2.123": "192.168.0.25"
 ```
 含义：访问 `10.2.2.123:<port>` 会被转发到 `192.168.0.25:<port>`。
+
+可选：若将 `allow_direct_ip_fallback` 设为 `true`，当 `vip_map` 中不存在目标时，服务端会直接把 `dst_vip` 当作真实 IPv4 访问。
 
 ### 认证
 服务端配置 JWT 参数 + 账号：
@@ -195,6 +200,22 @@ auth:
 桌面端调用 `POST /api/agent/login`：
 - 入参：`username`、`password`
 - 出参：`token`、`agent_id`、`ws_url`、`route_cidrs`
+
+`ws_url` 的生成逻辑（服务端）：
+1. 若配置了 `listen.public_ws_url`，直接返回该地址（推荐）
+2. 否则根据请求头推断：
+   - `X-Forwarded-Proto` -> `ws/wss`
+   - `X-Forwarded-Host` / `Host` -> 域名
+   - `X-Forwarded-Port` -> 端口（仅当 Host 不带端口时）
+
+反向代理场景最佳实践：
+- 最稳妥：在 `server.yaml` 显式配置 `listen.public_ws_url`
+- 同时让代理透传 `X-Forwarded-Proto`、`X-Forwarded-Host`、`X-Forwarded-Port`
+- `public_ws_url` 建议写外网可访问地址，例如：
+```yaml
+listen:
+  public_ws_url: "wss://tunnelv2.sms-uat.gree.com:30443/websocket/message"
+```
 
 agent 仍支持直接写 token（兼容旧方式）：
 ```yaml

--- a/go/cmd/htunnel-ui/app.go
+++ b/go/cmd/htunnel-ui/app.go
@@ -128,7 +128,11 @@ func (a *App) Connect(req LoginRequest) (StatusView, error) {
 	if strings.TrimSpace(loginResp.AgentID) != "" {
 		cfg.Agent.ID = strings.TrimSpace(loginResp.AgentID)
 	}
-	cfg.Server.URL = strings.TrimSpace(loginResp.WSURL)
+	if ws, err := wsURLFromServerBase(cfg.Server.BaseURL); err == nil {
+		cfg.Server.URL = ws
+	} else {
+		cfg.Server.URL = strings.TrimSpace(loginResp.WSURL)
+	}
 	if cfg.Server.URL == "" {
 		cfg.Server.URL = inferWSURLFromServerBase(cfg.Server.BaseURL)
 	}
@@ -317,21 +321,32 @@ func normalizeServerBaseURL(raw string) (string, error) {
 }
 
 func inferWSURLFromServerBase(serverBase string) string {
+	if ws, err := wsURLFromServerBase(serverBase); err == nil {
+		return ws
+	}
+	return "ws://127.0.0.1:8082/websocket/message"
+}
+
+func wsURLFromServerBase(serverBase string) (string, error) {
 	u, err := url.Parse(serverBase)
 	if err != nil {
-		return "ws://127.0.0.1:8082/websocket/message"
+		return "", err
 	}
 	switch strings.ToLower(u.Scheme) {
 	case "https":
 		u.Scheme = "wss"
-	default:
+	case "http":
 		u.Scheme = "ws"
+	case "wss", "ws":
+		// keep as-is
+	default:
+		return "", fmt.Errorf("unsupported scheme: %s", u.Scheme)
 	}
 	u.Path = "/websocket/message"
 	u.RawPath = ""
 	u.RawQuery = ""
 	u.Fragment = ""
-	return u.String()
+	return u.String(), nil
 }
 
 func parseLoginErrorMessage(body []byte) string {

--- a/go/configs/server.yaml
+++ b/go/configs/server.yaml
@@ -2,6 +2,8 @@ listen:
   addr: ":8082"
   path: "/websocket/message"
   login_path: "/api/agent/login"
+  # optional: explicit public ws endpoint returned to clients (recommended behind reverse proxy)
+  public_ws_url: ""
   tls:
     enabled: false
     cert_file: ""
@@ -22,6 +24,8 @@ auth:
         - "10.0.2.123/32"
 
 network:
+  # if true, unmapped vip will fallback to direct dst ip (only ipv4)
+  allow_direct_ip_fallback: false
   vip_map:
     "10.2.2.123": "172.28.52.13"
     "10.0.2.123": "172.28.52.13"

--- a/go/internal/agent/agent.go
+++ b/go/internal/agent/agent.go
@@ -166,7 +166,9 @@ func (s *Service) loginWithPassword() error {
 	} else if s.cfg.Agent.ID == "" {
 		s.cfg.Agent.ID = username
 	}
-	if strings.TrimSpace(lr.WSURL) != "" {
+	if ws, err := inferWSFromHTTPBase(baseURL); err == nil {
+		s.cfg.Server.URL = ws
+	} else if strings.TrimSpace(lr.WSURL) != "" {
 		s.cfg.Server.URL = strings.TrimSpace(lr.WSURL)
 	}
 	if len(lr.RouteCIDRs) > 0 {
@@ -195,4 +197,26 @@ func inferHTTPBaseFromWSURL(wsURL string) string {
 	u.RawQuery = ""
 	u.Fragment = ""
 	return strings.TrimRight(u.String(), "/")
+}
+
+func inferWSFromHTTPBase(baseURL string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return "", err
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	case "ws", "wss":
+		// keep as-is
+	default:
+		return "", fmt.Errorf("unsupported scheme: %s", u.Scheme)
+	}
+	u.Path = "/websocket/message"
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
 }

--- a/go/internal/server/auth_api.go
+++ b/go/internal/server/auth_api.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -68,7 +69,7 @@ func (s *Service) handleAgentLogin(w http.ResponseWriter, r *http.Request) {
 	resp := loginResponse{
 		Token:      token,
 		AgentID:    username,
-		WSURL:      inferWSURL(r, s.cfg.Listen.Path, s.cfg.Listen.TLS.Enabled),
+		WSURL:      resolveWSURL(r, s.cfg.Listen.PublicWSURL, s.cfg.Listen.Path, s.cfg.Listen.TLS.Enabled),
 		RouteCIDRs: resolveRouteCIDRs(account, s.cfg.Network.VIPMap),
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -86,12 +87,21 @@ func matchPassword(account UserAccount, password string) bool {
 	return false
 }
 
-func inferWSURL(r *http.Request, wsPath string, tlsEnabled bool) string {
+func resolveWSURL(r *http.Request, publicWSURL string, wsPath string, tlsEnabled bool) string {
+	if ws := strings.TrimSpace(publicWSURL); ws != "" {
+		if normalized := normalizePublicWSURL(ws, wsPath); normalized != "" {
+			return normalized
+		}
+	}
+	return inferWSURLFromRequest(r, wsPath, tlsEnabled)
+}
+
+func inferWSURLFromRequest(r *http.Request, wsPath string, tlsEnabled bool) string {
 	scheme := "ws"
 	if tlsEnabled {
 		scheme = "wss"
 	}
-	if xf := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); xf != "" {
+	if xf := firstHeaderValue(r.Header.Get("X-Forwarded-Proto")); xf != "" {
 		switch strings.ToLower(xf) {
 		case "https":
 			scheme = "wss"
@@ -102,11 +112,67 @@ func inferWSURL(r *http.Request, wsPath string, tlsEnabled bool) string {
 		scheme = "wss"
 	}
 
-	host := strings.TrimSpace(r.Host)
+	host := strings.TrimSpace(firstHeaderValue(r.Header.Get("X-Forwarded-Host")))
+	if host == "" {
+		host = strings.TrimSpace(r.Host)
+	}
+	if !hostHasPort(host) {
+		if p := firstHeaderValue(r.Header.Get("X-Forwarded-Port")); p != "" {
+			host = net.JoinHostPort(host, p)
+		}
+	}
 	if host == "" {
 		host = "127.0.0.1:8082"
 	}
 	return fmt.Sprintf("%s://%s%s", scheme, host, wsPath)
+}
+
+func normalizePublicWSURL(raw string, wsPath string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	case "ws", "wss":
+	default:
+		return ""
+	}
+	if u.Path == "" || u.Path == "/" {
+		u.Path = wsPath
+	}
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+func firstHeaderValue(v string) string {
+	if idx := strings.Index(v, ","); idx >= 0 {
+		return strings.TrimSpace(v[:idx])
+	}
+	return strings.TrimSpace(v)
+}
+
+func hostHasPort(host string) bool {
+	if host == "" {
+		return false
+	}
+	if _, _, err := net.SplitHostPort(host); err == nil {
+		return true
+	}
+	// net.SplitHostPort fails for plain hostnames and ipv6-without-brackets.
+	if strings.Count(host, ":") == 0 {
+		return false
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return false
+	}
+	// host containing ':' but not split-able is treated as already having port.
+	return true
 }
 
 func resolveRouteCIDRs(account UserAccount, vipMap map[string]string) []string {
@@ -157,4 +223,3 @@ func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
 }
-

--- a/go/internal/server/auth_api_test.go
+++ b/go/internal/server/auth_api_test.go
@@ -50,6 +50,56 @@ func TestHandleAgentLoginSuccess(t *testing.T) {
 	}
 }
 
+func TestHandleAgentLoginUsesPublicWSURL(t *testing.T) {
+	var cfg Config
+	cfg.normalize()
+	cfg.Listen.Path = "/websocket/message"
+	cfg.Listen.PublicWSURL = "wss://tunnelv2.sms-uat.gree.com:30443/websocket/message"
+	cfg.Auth.JWT.Secret = "change-me"
+	cfg.Auth.Users["alice"] = UserAccount{Password: "pass123"}
+
+	svc := New(cfg)
+	body := bytes.NewBufferString(`{"username":"alice","password":"pass123"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/login", body)
+	req.Host = "127.0.0.1:8082"
+	rec := httptest.NewRecorder()
+
+	svc.handleAgentLogin(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp loginResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.WSURL != "wss://tunnelv2.sms-uat.gree.com:30443/websocket/message" {
+		t.Fatalf("unexpected ws_url: %s", resp.WSURL)
+	}
+}
+
+func TestHandleAgentLoginUsesForwardedHostAndPort(t *testing.T) {
+	var cfg Config
+	cfg.normalize()
+	cfg.Auth.JWT.Secret = "change-me"
+	cfg.Auth.Users["alice"] = UserAccount{Password: "pass123"}
+
+	svc := New(cfg)
+	body := bytes.NewBufferString(`{"username":"alice","password":"pass123"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/login", body)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "tunnelv2.sms-uat.gree.com")
+	req.Header.Set("X-Forwarded-Port", "30443")
+	rec := httptest.NewRecorder()
+
+	svc.handleAgentLogin(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp loginResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.WSURL != "wss://tunnelv2.sms-uat.gree.com:30443/websocket/message" {
+		t.Fatalf("unexpected ws_url: %s", resp.WSURL)
+	}
+}
+
 func TestHandleAgentLoginFallbackRouteFromVIPMap(t *testing.T) {
 	var cfg Config
 	cfg.normalize()
@@ -90,4 +140,3 @@ func TestHandleAgentLoginUnauthorized(t *testing.T) {
 		t.Fatalf("expected status 401 got %d", rec.Code)
 	}
 }
-

--- a/go/internal/server/config.go
+++ b/go/internal/server/config.go
@@ -10,10 +10,11 @@ type UserAccount struct {
 
 type Config struct {
 	Listen struct {
-		Addr      string `yaml:"addr"`
-		Path      string `yaml:"path"`
-		LoginPath string `yaml:"login_path"`
-		TLS       struct {
+		Addr        string `yaml:"addr"`
+		Path        string `yaml:"path"`
+		LoginPath   string `yaml:"login_path"`
+		PublicWSURL string `yaml:"public_ws_url"`
+		TLS         struct {
 			Enabled  bool   `yaml:"enabled"`
 			CertFile string `yaml:"cert_file"`
 			KeyFile  string `yaml:"key_file"`
@@ -30,7 +31,8 @@ type Config struct {
 		Users map[string]UserAccount `yaml:"users"`
 	} `yaml:"auth"`
 	Network struct {
-		VIPMap map[string]string `yaml:"vip_map"`
+		VIPMap                map[string]string `yaml:"vip_map"`
+		AllowDirectIPFallback bool              `yaml:"allow_direct_ip_fallback"`
 	} `yaml:"network"`
 	Timeouts struct {
 		DialTimeoutSec  int `yaml:"dial_timeout_sec"`

--- a/go/internal/server/server.go
+++ b/go/internal/server/server.go
@@ -178,9 +178,9 @@ func (s *wsSession) handleOpen(env *protocol.Envelope) {
 		_ = s.send(&protocol.Envelope{Type: protocol.TypeOpenResp, ConnID: env.ConnID, Ok: false, Reason: "duplicate conn_id"})
 		return
 	}
-	realIP, ok := s.cfg.Network.VIPMap[env.DstVIP]
-	if !ok {
-		_ = s.send(&protocol.Envelope{Type: protocol.TypeOpenResp, ConnID: env.ConnID, Ok: false, Reason: "vip not mapped"})
+	realIP, err := s.resolveTargetIP(env.DstVIP)
+	if err != nil {
+		_ = s.send(&protocol.Envelope{Type: protocol.TypeOpenResp, ConnID: env.ConnID, Ok: false, Reason: err.Error()})
 		return
 	}
 	dst := net.JoinHostPort(realIP, strconv.Itoa(int(env.DstPort)))
@@ -194,6 +194,20 @@ func (s *wsSession) handleOpen(env *protocol.Envelope) {
 	log.Printf("open conn agent=%s conn_id=%s vip=%s:%d real=%s", s.agent, env.ConnID, env.DstVIP, env.DstPort, dst)
 
 	go s.pipeRemoteToAgent(env.ConnID, remote)
+}
+
+func (s *wsSession) resolveTargetIP(dstVIP string) (string, error) {
+	if realIP, ok := s.cfg.Network.VIPMap[dstVIP]; ok {
+		return realIP, nil
+	}
+	if !s.cfg.Network.AllowDirectIPFallback {
+		return "", errors.New("vip not mapped")
+	}
+	ip := net.ParseIP(dstVIP)
+	if ip == nil || ip.To4() == nil {
+		return "", errors.New("invalid direct ip")
+	}
+	return dstVIP, nil
 }
 
 func (s *wsSession) handleData(env *protocol.Envelope) {

--- a/go/internal/server/server_resolve_test.go
+++ b/go/internal/server/server_resolve_test.go
@@ -1,0 +1,43 @@
+package server
+
+import "testing"
+
+func TestResolveTargetIP_Mapped(t *testing.T) {
+	var cfg Config
+	cfg.normalize()
+	cfg.Network.VIPMap["10.2.2.123"] = "172.28.52.13"
+	s := &wsSession{cfg: cfg}
+
+	got, err := s.resolveTargetIP("10.2.2.123")
+	if err != nil {
+		t.Fatalf("resolveTargetIP failed: %v", err)
+	}
+	if got != "172.28.52.13" {
+		t.Fatalf("unexpected ip: %s", got)
+	}
+}
+
+func TestResolveTargetIP_DirectFallbackDisabled(t *testing.T) {
+	var cfg Config
+	cfg.normalize()
+	s := &wsSession{cfg: cfg}
+
+	if _, err := s.resolveTargetIP("10.8.0.10"); err == nil {
+		t.Fatal("expected error when direct fallback is disabled")
+	}
+}
+
+func TestResolveTargetIP_DirectFallbackEnabled(t *testing.T) {
+	var cfg Config
+	cfg.normalize()
+	cfg.Network.AllowDirectIPFallback = true
+	s := &wsSession{cfg: cfg}
+
+	got, err := s.resolveTargetIP("10.8.0.10")
+	if err != nil {
+		t.Fatalf("resolveTargetIP failed: %v", err)
+	}
+	if got != "10.8.0.10" {
+		t.Fatalf("unexpected ip: %s", got)
+	}
+}


### PR DESCRIPTION
- 新增 inferWSFromHTTPBase 和 wsURLFromServerBase 函数，用于根据http(s)地址推断ws(s)地址
- 在 agent 和 UI 初始化时优先使用推断的 WebSocket URL，兼容旧配置方式
- auth_api 支持通过 listen.public_ws_url 配置显式指定对外 WS 地址
- 优化代理场景下根据 X-Forwarded-* 请求头推断 WebSocket 地址的逻辑
- 增加 normalizePublicWSURL 函数标准化公开的 WS URL 格式
- 新增 network.allow_direct_ip_fallback 配置，支持 VIP 映射失败时直接使用目标 IPv4 连接
- wsSession 增加 resolveTargetIP 方法，优先映射 VIP，允许根据配置回退为直接 IP
- 编写单元测试覆盖 resolveTargetIP 和 public_ws_url 相关逻辑
- README 文档补充 network.allow_direct_ip_fallback 配置说明及代理部署最佳实践指导