### PR TITLE
chore(win-scripts): 优化Windows启动脚本以自动申请管理员权限

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ cd go
 - `bin/htunnel-ui`（`INCLUDE_UI=1` 默认启用）
 - `bin/tun2socks`
 - `configs/agent.yaml`
-- `start-agent.sh` / `start-agent.ps1`
-- `start-ui.sh` / `start-ui.ps1`
-- `start.sh` / `start.ps1`（默认优先启动 UI，不存在 UI 时回退到 agent）
+- `start-agent.sh` / `start-agent.ps1` / `start-agent.cmd`
+- `start-ui.sh` / `start-ui.ps1` / `start-ui.cmd`
+- `start.sh` / `start.ps1` / `start.cmd`（默认优先启动 UI，不存在 UI 时回退到 agent）
 
 示例（mac）：
 ```bash
@@ -169,6 +169,8 @@ cd go\dist\htunnel-agent-windows-amd64
 ```
 
 说明：UI 启动即要求管理员权限（避免连接时权限不足）。
+建议优先使用 `start-ui.cmd` / `start.cmd`，脚本会自动申请管理员权限并在异常时保留报错信息；直接双击 `bin\htunnel-ui.exe` 可能会因权限或配置错误而直接退出。
+若 Windows UI 仍然启动即退出，请确认系统已安装 Microsoft Edge WebView2 Runtime（Wails 桌面框架依赖）。
 
 注意：`tun2socks` 依赖 cgo，请在目标平台本机打包（mac 打 mac 包，windows 打 windows 包）。
 

--- a/go/internal/shared/privilege_windows.go
+++ b/go/internal/shared/privilege_windows.go
@@ -6,5 +6,40 @@ import "golang.org/x/sys/windows"
 
 func HasAdminPrivileges() (bool, error) {
 	token := windows.Token(0)
-	return token.IsElevated(), nil
+	elevated, err := token.IsElevated()
+	if err == nil && elevated {
+		return true, nil
+	}
+
+	// Some Windows environments can report a false negative for IsElevated()
+	// while the process is running under an Administrator context.
+	if member, memberErr := isUserAnAdmin(); memberErr == nil && member {
+		return true, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func isUserAnAdmin() (bool, error) {
+	shell32 := windows.NewLazySystemDLL("shell32.dll")
+	proc := shell32.NewProc("IsUserAnAdmin")
+
+	if err := shell32.Load(); err != nil {
+		return false, err
+	}
+	if err := proc.Find(); err != nil {
+		return false, err
+	}
+
+	r1, _, callErr := proc.Call()
+	if r1 == 0 {
+		if callErr != windows.ERROR_SUCCESS && callErr != windows.Errno(0) {
+			return false, callErr
+		}
+		return false, nil
+	}
+	return true, nil
 }

--- a/go/scripts/release.ps1
+++ b/go/scripts/release.ps1
@@ -107,23 +107,43 @@ Set-Location $scriptDir
 setlocal
 cd /d "%~dp0"
 
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$id=[Security.Principal.WindowsIdentity]::GetCurrent(); $p=New-Object Security.Principal.WindowsPrincipal($id); if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 0}else{exit 1}"
+if "%errorlevel%"=="0" goto run
+
 if /i "%~1"=="__elevated" (
-  shift
-  goto run
+  echo Failed to acquire Administrator privileges.
+  echo Please right-click this script and select "Run as administrator".
+  pause
+  exit /b 1
 )
 
-whoami /groups | find "S-1-16-12288" >NUL 2>NUL
+echo Requesting Administrator privileges...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Start-Process -FilePath '%~f0' -ArgumentList '__elevated' -Verb RunAs -WorkingDirectory '%~dp0'"
 if not "%errorlevel%"=="0" (
-  whoami /groups | find "S-1-16-16384" >NUL 2>NUL
+  echo Elevation was cancelled or failed.
+  pause
+  exit /b 1
 )
-if not "%errorlevel%"=="0" (
-  mshta "vbscript:CreateObject(""Shell.Application"").ShellExecute(""cmd.exe"",""/c cd /d """"%~dp0"""" ^&^& """"%~f0"""" __elevated"","""",""runas"",1)(close)"
-  exit /b 0
-)
+exit /b 0
 
 :run
+if not exist ".\bin\htunnel-agent.exe" (
+  echo Missing file: .\bin\htunnel-agent.exe
+  pause
+  exit /b 1
+)
+if not exist ".\configs\agent.yaml" (
+  echo Missing file: .\configs\agent.yaml
+  pause
+  exit /b 1
+)
 .\bin\htunnel-agent.exe -config .\configs\agent.yaml
-exit /b %errorlevel%
+set "exit_code=%errorlevel%"
+if not "%exit_code%"=="0" (
+  echo Process exited with code %exit_code%.
+  pause
+)
+exit /b %exit_code%
 '@ | Set-Content -Path (Join-Path $pkgDir "start-agent.cmd") -NoNewline
 
   @'
@@ -179,23 +199,43 @@ Set-Location $scriptDir
 setlocal
 cd /d "%~dp0"
 
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$id=[Security.Principal.WindowsIdentity]::GetCurrent(); $p=New-Object Security.Principal.WindowsPrincipal($id); if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 0}else{exit 1}"
+if "%errorlevel%"=="0" goto run
+
 if /i "%~1"=="__elevated" (
-  shift
-  goto run
+  echo Failed to acquire Administrator privileges.
+  echo Please right-click this script and select "Run as administrator".
+  pause
+  exit /b 1
 )
 
-whoami /groups | find "S-1-16-12288" >NUL 2>NUL
+echo Requesting Administrator privileges...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Start-Process -FilePath '%~f0' -ArgumentList '__elevated' -Verb RunAs -WorkingDirectory '%~dp0'"
 if not "%errorlevel%"=="0" (
-  whoami /groups | find "S-1-16-16384" >NUL 2>NUL
+  echo Elevation was cancelled or failed.
+  pause
+  exit /b 1
 )
-if not "%errorlevel%"=="0" (
-  mshta "vbscript:CreateObject(""Shell.Application"").ShellExecute(""cmd.exe"",""/c cd /d """"%~dp0"""" ^&^& """"%~f0"""" __elevated"","""",""runas"",1)(close)"
-  exit /b 0
-)
+exit /b 0
 
 :run
+if not exist ".\bin\htunnel-ui.exe" (
+  echo Missing file: .\bin\htunnel-ui.exe
+  pause
+  exit /b 1
+)
+if not exist ".\configs\agent.yaml" (
+  echo Missing file: .\configs\agent.yaml
+  pause
+  exit /b 1
+)
 .\bin\htunnel-ui.exe -config .\configs\agent.yaml
-exit /b %errorlevel%
+set "exit_code=%errorlevel%"
+if not "%exit_code%"=="0" (
+  echo Process exited with code %exit_code%.
+  pause
+)
+exit /b %exit_code%
 '@ | Set-Content -Path (Join-Path $pkgDir "start-ui.cmd") -NoNewline
   }
 

--- a/go/scripts/release.sh
+++ b/go/scripts/release.sh
@@ -121,23 +121,43 @@ PS1
 setlocal
 cd /d "%~dp0"
 
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$id=[Security.Principal.WindowsIdentity]::GetCurrent(); $p=New-Object Security.Principal.WindowsPrincipal($id); if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 0}else{exit 1}"
+if "%errorlevel%"=="0" goto run
+
 if /i "%~1"=="__elevated" (
-  shift
-  goto run
+  echo Failed to acquire Administrator privileges.
+  echo Please right-click this script and select "Run as administrator".
+  pause
+  exit /b 1
 )
 
-whoami /groups | find "S-1-16-12288" >NUL 2>NUL
+echo Requesting Administrator privileges...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Start-Process -FilePath '%~f0' -ArgumentList '__elevated' -Verb RunAs -WorkingDirectory '%~dp0'"
 if not "%errorlevel%"=="0" (
-  whoami /groups | find "S-1-16-16384" >NUL 2>NUL
+  echo Elevation was cancelled or failed.
+  pause
+  exit /b 1
 )
-if not "%errorlevel%"=="0" (
-  mshta "vbscript:CreateObject(""Shell.Application"").ShellExecute(""cmd.exe"",""/c cd /d """"%~dp0"""" ^&^& """"%~f0"""" __elevated"","""",""runas"",1)(close)"
-  exit /b 0
-)
+exit /b 0
 
 :run
+if not exist ".\bin\htunnel-agent.exe" (
+  echo Missing file: .\bin\htunnel-agent.exe
+  pause
+  exit /b 1
+)
+if not exist ".\configs\agent.yaml" (
+  echo Missing file: .\configs\agent.yaml
+  pause
+  exit /b 1
+)
 .\bin\htunnel-agent.exe -config .\configs\agent.yaml
-exit /b %errorlevel%
+set "exit_code=%errorlevel%"
+if not "%exit_code%"=="0" (
+  echo Process exited with code %exit_code%.
+  pause
+)
+exit /b %exit_code%
 CMD
 
   cat > "${pkg}/start.ps1" <<'PS1'
@@ -182,23 +202,43 @@ PS1
 setlocal
 cd /d "%~dp0"
 
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$id=[Security.Principal.WindowsIdentity]::GetCurrent(); $p=New-Object Security.Principal.WindowsPrincipal($id); if($p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)){exit 0}else{exit 1}"
+if "%errorlevel%"=="0" goto run
+
 if /i "%~1"=="__elevated" (
-  shift
-  goto run
+  echo Failed to acquire Administrator privileges.
+  echo Please right-click this script and select "Run as administrator".
+  pause
+  exit /b 1
 )
 
-whoami /groups | find "S-1-16-12288" >NUL 2>NUL
+echo Requesting Administrator privileges...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Start-Process -FilePath '%~f0' -ArgumentList '__elevated' -Verb RunAs -WorkingDirectory '%~dp0'"
 if not "%errorlevel%"=="0" (
-  whoami /groups | find "S-1-16-16384" >NUL 2>NUL
+  echo Elevation was cancelled or failed.
+  pause
+  exit /b 1
 )
-if not "%errorlevel%"=="0" (
-  mshta "vbscript:CreateObject(""Shell.Application"").ShellExecute(""cmd.exe"",""/c cd /d """"%~dp0"""" ^&^& """"%~f0"""" __elevated"","""",""runas"",1)(close)"
-  exit /b 0
-)
+exit /b 0
 
 :run
+if not exist ".\bin\htunnel-ui.exe" (
+  echo Missing file: .\bin\htunnel-ui.exe
+  pause
+  exit /b 1
+)
+if not exist ".\configs\agent.yaml" (
+  echo Missing file: .\configs\agent.yaml
+  pause
+  exit /b 1
+)
 .\bin\htunnel-ui.exe -config .\configs\agent.yaml
-exit /b %errorlevel%
+set "exit_code=%errorlevel%"
+if not "%exit_code%"=="0" (
+  echo Process exited with code %exit_code%.
+  pause
+)
+exit /b %exit_code%
 CMD
   fi
 


### PR DESCRIPTION
- 为 start-agent.cmd 和 start-ui.cmd 脚本添加自动请求管理员权限功能
- 提升启动脚本的权限检测逻辑，提示用户以管理员身份运行
- 脚本在权限不足时暂停并显示错误信息，便于排查
- 在README中补充 Windows UI 启动依赖 Edge WebView2 Runtime 的说明
- 增加对缺失文件的检测及错误提示，防止启动过程异常退出
- 优化脚本流程保证运行状态的正确返回与错误码处理