### PR TITLE
feat(windows): 支持 Windows 下自动检测及安装 TAP/Wintun 网卡驱动

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ cd go
 - `bin/htunnel-agent`
 - `bin/htunnel-ui`（`INCLUDE_UI=1` 默认启用）
 - `bin/tun2socks`
+- `bin/tap-windows-installer.exe`（可选，若存在会被打进 windows 包并被 `start-*.cmd` 自动调用）
 - `configs/agent.yaml`
 - `start-agent.sh` / `start-agent.ps1` / `start-agent.cmd`
 - `start-ui.sh` / `start-ui.ps1` / `start-ui.cmd`
@@ -169,7 +170,8 @@ cd go\dist\htunnel-agent-windows-amd64
 ```
 
 说明：UI 启动即要求管理员权限（避免连接时权限不足）。
-建议优先使用 `start-ui.cmd` / `start.cmd`，脚本会自动申请管理员权限并在异常时保留报错信息；直接双击 `bin\htunnel-ui.exe` 可能会因权限或配置错误而直接退出。
+建议优先使用 `start-ui.cmd` / `start.cmd`，脚本会自动申请管理员权限，且在缺少 TAP/Wintun 时会尝试运行包内 `bin\tap-windows-installer.exe`（若已打包）。
+直接双击 `bin\htunnel-ui.exe` 可能会因权限或配置错误而直接退出。
 若 Windows UI 仍然启动即退出，请确认系统已安装 Microsoft Edge WebView2 Runtime（Wails 桌面框架依赖）。
 
 注意：`tun2socks` 依赖 cgo，请在目标平台本机打包（mac 打 mac 包，windows 打 windows 包）。
@@ -256,6 +258,13 @@ tun:
   route_cidrs:
     - "10.2.2.123/32"
 ```
+Windows 注意：
+- `name: "utun9"` 仅适用于 macOS 示例。
+- Windows 下 `tun.name` 为空或是 `utun*` 时，会自动探测现有 TAP/Wintun 网卡并自动填充。
+- 若探测不到，`start-*.cmd` 会尝试执行 `bin\tap-windows-installer.exe` 自动安装驱动（如果该文件已随包提供）。
+- 可用管理员 PowerShell 查看可选网卡名：`Get-NetAdapter | Format-Table -Auto Name, InterfaceDescription, Status`
+- 如果仍没有 TAP/Wintun 网卡，请先安装对应驱动（例如 OpenVPN TAP-Windows 或 Wintun）。
+
 开发环境可直接安装到 `go/bin`（中国网络可用镜像）：
 ```bash
 make install-tun2socks

--- a/go/cmd/htunnel-ui/app.go
+++ b/go/cmd/htunnel-ui/app.go
@@ -256,7 +256,11 @@ func defaultAgentConfig() agent.Config {
 	cfg.Agent.Version = "0.1.0"
 	cfg.Socks.Listen = "127.0.0.1:1080"
 	cfg.Tun.Enabled = true
-	cfg.Tun.Name = "utun9"
+	if runtime.GOOS == "windows" {
+		cfg.Tun.Name = ""
+	} else {
+		cfg.Tun.Name = "utun9"
+	}
 	cfg.Tun.Addr = "10.2.2.2"
 	cfg.Tun.Gateway = "10.2.2.1"
 	cfg.Tun.Mask = "255.255.255.0"
@@ -414,7 +418,12 @@ func applyLocalDefaults(cfg *agent.Config) error {
 		cfg.Socks.Listen = "127.0.0.1:1080"
 	}
 	if cfg.Tun.Name == "" {
-		cfg.Tun.Name = "utun9"
+		if runtime.GOOS == "windows" {
+			// Empty on Windows means "auto-detect TAP/Wintun adapter".
+			cfg.Tun.Name = ""
+		} else {
+			cfg.Tun.Name = "utun9"
+		}
 	}
 	if cfg.Tun.Addr == "" {
 		cfg.Tun.Addr = "10.2.2.2"

--- a/go/configs/agent.yaml
+++ b/go/configs/agent.yaml
@@ -23,6 +23,9 @@ socks:
 tun:
   enabled: true
   binary: ""
+  # macOS example: utun9
+  # Windows: empty or "utun*" will trigger auto-detect TAP/Wintun adapter.
+  # If not found, launcher can auto-run bundled bin/tap-windows-installer.exe.
   name: "utun9"
   addr: "10.2.2.2"
   gateway: "10.2.2.1"

--- a/go/drivers/windows/README.md
+++ b/go/drivers/windows/README.md
@@ -1,0 +1,9 @@
+Place the Windows TAP driver installer here before packaging:
+
+- `tap-windows-installer.exe`
+
+When this file exists, `scripts/release.sh` and `scripts/release.ps1` will copy it to:
+
+- `dist/htunnel-agent-windows-*/bin/tap-windows-installer.exe`
+
+Then `start-agent.cmd` / `start-ui.cmd` will auto-run it (silent mode `/S`) if no TAP/Wintun adapter is detected.

--- a/go/internal/agent/agent.go
+++ b/go/internal/agent/agent.go
@@ -10,7 +10,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os/exec"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -43,6 +45,9 @@ func (s *Service) Run(ctx context.Context) error {
 		if err := requireAdminPrivilege(); err != nil {
 			return err
 		}
+		if err := validateTunConfig(runtime.GOOS, &s.cfg); err != nil {
+			return err
+		}
 	}
 
 	session := NewSession(s.cfg)
@@ -58,6 +63,121 @@ func (s *Service) Run(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func validateTunConfig(goos string, cfg *Config) error {
+	if goos != "windows" || !cfg.Tun.Enabled {
+		return nil
+	}
+	name := strings.TrimSpace(cfg.Tun.Name)
+
+	// On Windows, empty name (or macOS placeholder utun*) triggers auto-detection.
+	if name == "" || strings.HasPrefix(strings.ToLower(name), "utun") {
+		detected, err := detectWindowsTunAdapterName()
+		if err != nil {
+			if name == "" {
+				return fmt.Errorf("tun.name auto-detect failed: %w", err)
+			}
+			return fmt.Errorf("invalid tun.name=%q on windows and auto-detect failed: %w", name, err)
+		}
+		cfg.Tun.Name = detected
+		log.Printf("auto selected windows tun adapter: %s", detected)
+	}
+	return nil
+}
+
+type windowsAdapter struct {
+	Name                 string `json:"Name"`
+	InterfaceDescription string `json:"InterfaceDescription"`
+	Status               string `json:"Status"`
+}
+
+func detectWindowsTunAdapterName() (string, error) {
+	cmd := exec.Command(
+		"powershell",
+		"-NoProfile",
+		"-ExecutionPolicy", "Bypass",
+		"-Command",
+		"Get-NetAdapter -ErrorAction Stop | Select-Object Name,InterfaceDescription,Status | ConvertTo-Json -Compress",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("query adapters failed: %w, output=%s", err, strings.TrimSpace(string(output)))
+	}
+
+	adapters, err := parseWindowsAdapters(output)
+	if err != nil {
+		return "", err
+	}
+
+	type candidate struct {
+		name  string
+		score int
+	}
+	var cands []candidate
+	for _, adapter := range adapters {
+		score, ok := windowsTunCandidateScore(adapter)
+		if !ok {
+			continue
+		}
+		cands = append(cands, candidate{name: adapter.Name, score: score})
+	}
+	if len(cands) == 0 {
+		return "", fmt.Errorf("no TAP/Wintun adapter found; install a TAP/Wintun driver or set tun.name manually (check with Get-NetAdapter)")
+	}
+
+	sort.Slice(cands, func(i, j int) bool {
+		if cands[i].score != cands[j].score {
+			return cands[i].score > cands[j].score
+		}
+		return cands[i].name < cands[j].name
+	})
+	return cands[0].name, nil
+}
+
+func parseWindowsAdapters(raw []byte) ([]windowsAdapter, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("query adapters returned empty output")
+	}
+
+	if raw[0] == '[' {
+		var adapters []windowsAdapter
+		if err := json.Unmarshal(raw, &adapters); err != nil {
+			return nil, fmt.Errorf("parse adapter list failed: %w", err)
+		}
+		return adapters, nil
+	}
+
+	var single windowsAdapter
+	if err := json.Unmarshal(raw, &single); err != nil {
+		return nil, fmt.Errorf("parse adapter item failed: %w", err)
+	}
+	return []windowsAdapter{single}, nil
+}
+
+func windowsTunCandidateScore(adapter windowsAdapter) (int, bool) {
+	name := strings.ToLower(strings.TrimSpace(adapter.Name))
+	desc := strings.ToLower(strings.TrimSpace(adapter.InterfaceDescription))
+	status := strings.ToLower(strings.TrimSpace(adapter.Status))
+	joined := name + " " + desc
+
+	if name == "" || status == "disabled" {
+		return 0, false
+	}
+	if strings.Contains(joined, "isatap") {
+		return 0, false
+	}
+	if strings.Contains(joined, "wintun") {
+		return 100, true
+	}
+	if strings.Contains(joined, "tap-windows") || strings.Contains(joined, "tap-win32") {
+		return 90, true
+	}
+	if strings.Contains(joined, "tap adapter") || strings.Contains(joined, "openvpn tap") {
+		return 80, true
+	}
+	return 0, false
 }
 
 func requireAdminPrivilege() error {

--- a/go/scripts/release.ps1
+++ b/go/scripts/release.ps1
@@ -66,6 +66,11 @@ foreach ($target in $targets) {
   }
 
   Copy-Item (Join-Path $rootDir "configs/agent.yaml") (Join-Path $pkgDir "configs/agent.yaml") -Force
+  $tapInstaller = Join-Path $rootDir "drivers/windows/tap-windows-installer.exe"
+  if ($os -eq "windows" -and (Test-Path $tapInstaller)) {
+    Copy-Item $tapInstaller (Join-Path $pkgDir "bin/tap-windows-installer.exe") -Force
+    Write-Host "[release] bundled Windows TAP driver installer"
+  }
 
   @'
 #!/usr/bin/env bash
@@ -137,6 +142,24 @@ if not exist ".\configs\agent.yaml" (
   pause
   exit /b 1
 )
+
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+if "%errorlevel%"=="0" goto launch
+
+echo No TAP/Wintun adapter found. Trying bundled driver installer...
+if exist ".\bin\tap-windows-installer.exe" (
+  start "" /wait ".\bin\tap-windows-installer.exe" /S
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+  if "%errorlevel%"=="0" goto launch
+  echo Driver installer finished, but TAP/Wintun adapter is still not available.
+) else (
+  echo Missing bundled driver installer: .\bin\tap-windows-installer.exe
+)
+echo Please install TAP/Wintun driver, then run again.
+pause
+exit /b 1
+
+:launch
 .\bin\htunnel-agent.exe -config .\configs\agent.yaml
 set "exit_code=%errorlevel%"
 if not "%exit_code%"=="0" (
@@ -229,6 +252,24 @@ if not exist ".\configs\agent.yaml" (
   pause
   exit /b 1
 )
+
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+if "%errorlevel%"=="0" goto launch
+
+echo No TAP/Wintun adapter found. Trying bundled driver installer...
+if exist ".\bin\tap-windows-installer.exe" (
+  start "" /wait ".\bin\tap-windows-installer.exe" /S
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+  if "%errorlevel%"=="0" goto launch
+  echo Driver installer finished, but TAP/Wintun adapter is still not available.
+) else (
+  echo Missing bundled driver installer: .\bin\tap-windows-installer.exe
+)
+echo Please install TAP/Wintun driver, then run again.
+pause
+exit /b 1
+
+:launch
 .\bin\htunnel-ui.exe -config .\configs\agent.yaml
 set "exit_code=%errorlevel%"
 if not "%exit_code%"=="0" (
@@ -245,6 +286,7 @@ HTunnel package usage:
 - start-ui.cmd / start-ui.ps1       : start desktop UI on Windows (requires admin)
 - start-agent.sh / start-ui.sh      : start on macOS/Linux (requires root/sudo)
 - start.cmd                         : default starter on Windows
+- bin/tap-windows-installer.exe     : optional Windows TAP driver installer (auto-run by start-*.cmd when adapter missing)
 - configs/agent.yaml               : client config
 '@ | Set-Content -Path (Join-Path $pkgDir "README.txt") -NoNewline
 

--- a/go/scripts/release.sh
+++ b/go/scripts/release.sh
@@ -64,6 +64,10 @@ for target in ${TARGETS}; do
   )
 
   cp "${ROOT_DIR}/configs/agent.yaml" "${pkg}/configs/agent.yaml"
+  if [[ "${os}" == "windows" && -f "${ROOT_DIR}/drivers/windows/tap-windows-installer.exe" ]]; then
+    cp "${ROOT_DIR}/drivers/windows/tap-windows-installer.exe" "${pkg}/bin/tap-windows-installer.exe"
+    echo "[release] bundled Windows TAP driver installer"
+  fi
 
   cat > "${pkg}/start-agent.sh" <<'SH'
 #!/usr/bin/env bash
@@ -151,6 +155,24 @@ if not exist ".\configs\agent.yaml" (
   pause
   exit /b 1
 )
+
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+if "%errorlevel%"=="0" goto launch
+
+echo No TAP/Wintun adapter found. Trying bundled driver installer...
+if exist ".\bin\tap-windows-installer.exe" (
+  start "" /wait ".\bin\tap-windows-installer.exe" /S
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+  if "%errorlevel%"=="0" goto launch
+  echo Driver installer finished, but TAP/Wintun adapter is still not available.
+) else (
+  echo Missing bundled driver installer: .\bin\tap-windows-installer.exe
+)
+echo Please install TAP/Wintun driver, then run again.
+pause
+exit /b 1
+
+:launch
 .\bin\htunnel-agent.exe -config .\configs\agent.yaml
 set "exit_code=%errorlevel%"
 if not "%exit_code%"=="0" (
@@ -232,6 +254,24 @@ if not exist ".\configs\agent.yaml" (
   pause
   exit /b 1
 )
+
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+if "%errorlevel%"=="0" goto launch
+
+echo No TAP/Wintun adapter found. Trying bundled driver installer...
+if exist ".\bin\tap-windows-installer.exe" (
+  start "" /wait ".\bin\tap-windows-installer.exe" /S
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+  if "%errorlevel%"=="0" goto launch
+  echo Driver installer finished, but TAP/Wintun adapter is still not available.
+) else (
+  echo Missing bundled driver installer: .\bin\tap-windows-installer.exe
+)
+echo Please install TAP/Wintun driver, then run again.
+pause
+exit /b 1
+
+:launch
 .\bin\htunnel-ui.exe -config .\configs\agent.yaml
 set "exit_code=%errorlevel%"
 if not "%exit_code%"=="0" (
@@ -248,6 +288,7 @@ HTunnel package usage:
 - start-ui.cmd / start-ui.ps1       : start desktop UI on Windows (requires admin)
 - start-agent.sh / start-ui.sh       : start on macOS/Linux (requires root/sudo)
 - start.cmd                          : default starter on Windows
+- bin/tap-windows-installer.exe      : optional Windows TAP driver installer (auto-run by start-*.cmd when adapter missing)
 - configs/agent.yaml               : client config
 TXT
 


### PR DESCRIPTION
- 在 Windows 平台下 tun.name 为空或匹配 utun* 时自动探测 TAP/Wintun 适配器名称
- 实现基于 PowerShell 的 Get-NetAdapter 查询与适配器评分筛选机制
- 失败时返回明确错误，提示用户手动指定或安装驱动
- 在启动脚本 start-*.cmd 中加入检测逻辑，缺少适配器时自动运行捆绑的 tap-windows-installer.exe
- release 脚本自动将 tap-windows-installer.exe 打包进 Windows 发行包的 bin 目录
- 更新配置示例和 README，说明 Windows 下自动检测行为及驱动安装建议
- UI 启动默认开启 Tun 并基于系统自动设置 tun.name，Windows 为空触发自动检测逻辑