### PR TITLE
fix(agent): 优化适配器状态判断逻辑并修复误判问题

### DIFF
--- a/go/internal/agent/agent.go
+++ b/go/internal/agent/agent.go
@@ -162,20 +162,31 @@ func windowsTunCandidateScore(adapter windowsAdapter) (int, bool) {
 	status := strings.ToLower(strings.TrimSpace(adapter.Status))
 	joined := name + " " + desc
 
-	if name == "" || status == "disabled" {
+	if name == "" {
+		return 0, false
+	}
+	switch status {
+	case "disabled", "not present", "notpresent", "unknown":
 		return 0, false
 	}
 	if strings.Contains(joined, "isatap") {
 		return 0, false
 	}
+	statusScore := 0
+	switch status {
+	case "up":
+		statusScore = 20
+	case "disconnected", "dormant":
+		statusScore = 10
+	}
 	if strings.Contains(joined, "wintun") {
-		return 100, true
+		return 100 + statusScore, true
 	}
 	if strings.Contains(joined, "tap-windows") || strings.Contains(joined, "tap-win32") {
-		return 90, true
+		return 90 + statusScore, true
 	}
 	if strings.Contains(joined, "tap adapter") || strings.Contains(joined, "openvpn tap") {
-		return 80, true
+		return 80 + statusScore, true
 	}
 	return 0, false
 }

--- a/go/scripts/release.ps1
+++ b/go/scripts/release.ps1
@@ -185,7 +185,7 @@ pause
 exit /b 1
 
 :has_tap_adapter
-powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun|tap' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue; $ok=$false; foreach($n in $a){$name=[string]$n.Name; $desc=[string]$n.InterfaceDescription; if((($name -match 'wintun') -or ($desc -match 'wintun') -or ($desc -match 'tap-windows') -or ($desc -match 'tap-win32') -or ($desc -match 'tap adapter') -or ($desc -match 'openvpn tap')) -and ($name -notmatch 'isatap') -and ($desc -notmatch 'isatap')){$ok=$true; break}}; if($ok){exit 0}else{exit 1}"
 exit /b %errorlevel%
 
 :launch
@@ -318,7 +318,7 @@ pause
 exit /b 1
 
 :has_tap_adapter
-powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun|tap' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue; $ok=$false; foreach($n in $a){$name=[string]$n.Name; $desc=[string]$n.InterfaceDescription; if((($name -match 'wintun') -or ($desc -match 'wintun') -or ($desc -match 'tap-windows') -or ($desc -match 'tap-win32') -or ($desc -match 'tap adapter') -or ($desc -match 'openvpn tap')) -and ($name -notmatch 'isatap') -and ($desc -notmatch 'isatap')){$ok=$true; break}}; if($ok){exit 0}else{exit 1}"
 exit /b %errorlevel%
 
 :launch

--- a/go/scripts/release.sh
+++ b/go/scripts/release.sh
@@ -197,7 +197,7 @@ pause
 exit /b 1
 
 :has_tap_adapter
-powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun|tap' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue; $ok=$false; foreach($n in $a){$name=[string]$n.Name; $desc=[string]$n.InterfaceDescription; if((($name -match 'wintun') -or ($desc -match 'wintun') -or ($desc -match 'tap-windows') -or ($desc -match 'tap-win32') -or ($desc -match 'tap adapter') -or ($desc -match 'openvpn tap')) -and ($name -notmatch 'isatap') -and ($desc -notmatch 'isatap')){$ok=$true; break}}; if($ok){exit 0}else{exit 1}"
 exit /b %errorlevel%
 
 :launch
@@ -319,7 +319,7 @@ pause
 exit /b 1
 
 :has_tap_adapter
-powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue | ? { $_.Name -match 'wintun|tap' -or $_.InterfaceDescription -match 'wintun|tap-windows|tap-win32|tap adapter|openvpn tap' }; if($a){exit 0}else{exit 1}"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$a=Get-NetAdapter -IncludeHidden -ErrorAction SilentlyContinue; $ok=$false; foreach($n in $a){$name=[string]$n.Name; $desc=[string]$n.InterfaceDescription; if((($name -match 'wintun') -or ($desc -match 'wintun') -or ($desc -match 'tap-windows') -or ($desc -match 'tap-win32') -or ($desc -match 'tap adapter') -or ($desc -match 'openvpn tap')) -and ($name -notmatch 'isatap') -and ($desc -notmatch 'isatap')){$ok=$true; break}}; if($ok){exit 0}else{exit 1}"
 exit /b %errorlevel%
 
 :launch


### PR DESCRIPTION
- 按状态分配适配器评分，增强优先级判断准确性
- 排除名称或描述包含"isatap"的适配器
- 改进 Windows 脚本中对 TAP 适配器的检测逻辑
- 确保脚本排除 isatap 相关适配器避免误判
- 统一多个脚本和 Go 代码中适配器匹配规则