### PR TITLE
fix(agent): 修复Windows TUN适配器自动检测并改进路由命令生成

### DIFF
--- a/go/cmd/htunnel-ui/frontend/dist/app.js
+++ b/go/cmd/htunnel-ui/frontend/dist/app.js
@@ -17,10 +17,35 @@ function setVal(id, value) {
   if (el) el.value = value || "";
 }
 
+function showToast(msg, ok = false) {
+  const text = String(msg || "").trim();
+  if (!text) return;
+
+  const container = document.getElementById("toastContainer");
+  if (!container) return;
+
+  const toast = document.createElement("div");
+  toast.className = `toast ${ok ? "success" : "error"}`;
+  toast.textContent = text;
+  container.appendChild(toast);
+
+  requestAnimationFrame(() => {
+    toast.classList.add("show");
+  });
+
+  setTimeout(() => {
+    toast.classList.remove("show");
+    setTimeout(() => {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 180);
+  }, 2200);
+}
+
 function setMsg(msg, ok = false) {
-  const el = document.getElementById("msg");
-  el.style.color = ok ? "#0f766e" : "#b3261e";
-  el.textContent = msg || "";
+  if (!msg) return;
+  showToast(msg, ok);
 }
 
 let currentRunning = false;
@@ -94,7 +119,6 @@ document.getElementById("btnToggle").addEventListener("click", toggleConnect);
 document.getElementById("btnRefresh").addEventListener("click", async () => {
   try {
     await refreshStatus();
-    setMsg("");
   } catch (e) {
     setMsg(`刷新失败: ${e}`);
   }
@@ -117,4 +141,3 @@ setInterval(async () => {
     await refreshStatus();
   } catch (_) {}
 }, 3000);
-

--- a/go/cmd/htunnel-ui/frontend/dist/index.html
+++ b/go/cmd/htunnel-ui/frontend/dist/index.html
@@ -27,11 +27,9 @@
         </div>
         <p class="status" id="statusText">状态：未知</p>
       </section>
-
-      <p id="msg" class="msg"></p>
     </main>
+    <div id="toastContainer" class="toast-container" aria-live="polite"></div>
 
     <script src="./app.js"></script>
   </body>
 </html>
-

--- a/go/cmd/htunnel-ui/frontend/dist/styles.css
+++ b/go/cmd/htunnel-ui/frontend/dist/styles.css
@@ -6,6 +6,7 @@
   --muted: #5f6b85;
   --accent: #0f766e;
   --accent-hover: #0a5a55;
+  --danger: #b3261e;
 }
 
 * {
@@ -13,15 +14,25 @@
   font-family: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
 }
 
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
 body {
   margin: 0;
   background: radial-gradient(circle at 0 0, #d7e3ff 0%, var(--bg) 45%);
   color: var(--text);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
 }
 
 .app {
   width: min(620px, 94vw);
-  margin: 14px auto;
+  margin: 14px 0;
 }
 
 h1 {
@@ -82,11 +93,45 @@ button:hover {
 }
 
 .status,
-.msg {
+.toast {
   margin: 10px 0 0;
 }
 
-.msg {
-  color: #b3261e;
-  min-height: 18px;
+.toast-container {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.toast {
+  min-width: 200px;
+  max-width: min(420px, 90vw);
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: #fff;
+  color: var(--text);
+  box-shadow: 0 8px 20px rgba(10, 28, 61, 0.14);
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.16s ease, transform 0.16s ease;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast.success {
+  border-color: rgba(15, 118, 110, 0.35);
+}
+
+.toast.error {
+  border-color: rgba(179, 38, 30, 0.35);
+  color: var(--danger);
 }

--- a/go/internal/agent/agent.go
+++ b/go/internal/agent/agent.go
@@ -37,10 +37,6 @@ func (s *Service) Run(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := s.cfg.EnsureRouteCommands(runtime.GOOS); err != nil {
-		return err
-	}
-
 	if s.cfg.Tun.Enabled {
 		if err := requireAdminPrivilege(); err != nil {
 			return err
@@ -48,6 +44,9 @@ func (s *Service) Run(ctx context.Context) error {
 		if err := validateTunConfig(runtime.GOOS, &s.cfg); err != nil {
 			return err
 		}
+	}
+	if err := s.cfg.EnsureRouteCommands(runtime.GOOS); err != nil {
+		return err
 	}
 
 	session := NewSession(s.cfg)
@@ -73,16 +72,25 @@ func validateTunConfig(goos string, cfg *Config) error {
 
 	// On Windows, empty name (or macOS placeholder utun*) triggers auto-detection.
 	if name == "" || strings.HasPrefix(strings.ToLower(name), "utun") {
-		detected, err := detectWindowsTunAdapterName()
+		detected, err := detectWindowsTunAdapter()
 		if err != nil {
 			if name == "" {
 				return fmt.Errorf("tun.name auto-detect failed: %w", err)
 			}
 			return fmt.Errorf("invalid tun.name=%q on windows and auto-detect failed: %w", name, err)
 		}
-		cfg.Tun.Name = detected
-		log.Printf("auto selected windows tun adapter: %s", detected)
+		cfg.Tun.Name = detected.Name
+		cfg.Tun.InterfaceIndex = detected.IfIndex
+		log.Printf("auto selected windows tun adapter: %s (ifIndex=%d)", detected.Name, detected.IfIndex)
+		return nil
 	}
+
+	ifIndex, err := detectWindowsTunInterfaceIndex(name)
+	if err != nil {
+		log.Printf("resolve tun interface index failed for %q: %v", name, err)
+		return nil
+	}
+	cfg.Tun.InterfaceIndex = ifIndex
 	return nil
 }
 
@@ -90,29 +98,37 @@ type windowsAdapter struct {
 	Name                 string `json:"Name"`
 	InterfaceDescription string `json:"InterfaceDescription"`
 	Status               string `json:"Status"`
+	IfIndex              int    `json:"ifIndex"`
 }
 
-func detectWindowsTunAdapterName() (string, error) {
+func fetchWindowsAdapters() ([]windowsAdapter, error) {
 	cmd := exec.Command(
 		"powershell",
 		"-NoProfile",
 		"-ExecutionPolicy", "Bypass",
 		"-Command",
-		"[Console]::OutputEncoding=[System.Text.Encoding]::UTF8; Get-NetAdapter -ErrorAction Stop | Select-Object Name,InterfaceDescription,Status | ConvertTo-Json -Compress",
+		"[Console]::OutputEncoding=[System.Text.Encoding]::UTF8; Get-NetAdapter -ErrorAction Stop | Select-Object Name,InterfaceDescription,Status,ifIndex | ConvertTo-Json -Compress",
 	)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("query adapters failed: %w, output=%s", err, strings.TrimSpace(string(output)))
+		return nil, fmt.Errorf("query adapters failed: %w, output=%s", err, strings.TrimSpace(string(output)))
 	}
 
 	adapters, err := parseWindowsAdapters(output)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
+	return adapters, nil
+}
 
+func detectWindowsTunAdapter() (windowsAdapter, error) {
+	adapters, err := fetchWindowsAdapters()
+	if err != nil {
+		return windowsAdapter{}, err
+	}
 	type candidate struct {
-		name  string
-		score int
+		adapter windowsAdapter
+		score   int
 	}
 	var cands []candidate
 	for _, adapter := range adapters {
@@ -120,19 +136,39 @@ func detectWindowsTunAdapterName() (string, error) {
 		if !ok {
 			continue
 		}
-		cands = append(cands, candidate{name: adapter.Name, score: score})
+		cands = append(cands, candidate{adapter: adapter, score: score})
 	}
 	if len(cands) == 0 {
-		return "", fmt.Errorf("no TAP/Wintun adapter found; install a TAP/Wintun driver or set tun.name manually (check with Get-NetAdapter)")
+		return windowsAdapter{}, fmt.Errorf("no TAP/Wintun adapter found; install a TAP/Wintun driver or set tun.name manually (check with Get-NetAdapter)")
 	}
 
 	sort.Slice(cands, func(i, j int) bool {
 		if cands[i].score != cands[j].score {
 			return cands[i].score > cands[j].score
 		}
-		return cands[i].name < cands[j].name
+		return cands[i].adapter.Name < cands[j].adapter.Name
 	})
-	return cands[0].name, nil
+	return cands[0].adapter, nil
+}
+
+func detectWindowsTunInterfaceIndex(name string) (int, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return 0, fmt.Errorf("empty adapter name")
+	}
+	adapters, err := fetchWindowsAdapters()
+	if err != nil {
+		return 0, err
+	}
+	for _, adapter := range adapters {
+		if strings.EqualFold(strings.TrimSpace(adapter.Name), name) {
+			if adapter.IfIndex <= 0 {
+				return 0, fmt.Errorf("adapter %q has invalid ifIndex=%d", adapter.Name, adapter.IfIndex)
+			}
+			return adapter.IfIndex, nil
+		}
+	}
+	return 0, fmt.Errorf("adapter %q not found", name)
 }
 
 func parseWindowsAdapters(raw []byte) ([]windowsAdapter, error) {

--- a/go/internal/agent/config.go
+++ b/go/internal/agent/config.go
@@ -26,6 +26,7 @@ type Config struct {
 		Enabled                  bool     `yaml:"enabled"`
 		Binary                   string   `yaml:"binary"`
 		Name                     string   `yaml:"name"`
+		InterfaceIndex           int      `yaml:"interface_index"`
 		Addr                     string   `yaml:"addr"`
 		Gateway                  string   `yaml:"gateway"`
 		Mask                     string   `yaml:"mask"`

--- a/go/internal/agent/routes.go
+++ b/go/internal/agent/routes.go
@@ -17,7 +17,7 @@ func (c *Config) EnsureRouteCommands(goos string) error {
 	if len(cidrs) == 0 {
 		return nil
 	}
-	setup, cleanup, err := BuildRouteCommands(goos, cidrs, c.Tun.Addr, c.Tun.Gateway)
+	setup, cleanup, err := BuildRouteCommands(goos, cidrs, c.Tun.Addr, c.Tun.Gateway, c.Tun.InterfaceIndex)
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func NormalizeRouteCIDRs(routeCIDRs []string) ([]string, error) {
 	return out, nil
 }
 
-func BuildRouteCommands(goos string, routeCIDRs []string, tunAddr string, tunGateway string) ([]string, []string, error) {
+func BuildRouteCommands(goos string, routeCIDRs []string, tunAddr string, tunGateway string, tunIfIndex int) ([]string, []string, error) {
 	cidrs, err := NormalizeRouteCIDRs(routeCIDRs)
 	if err != nil {
 		return nil, nil, err
@@ -78,7 +78,7 @@ func BuildRouteCommands(goos string, routeCIDRs []string, tunAddr string, tunGat
 	case "darwin":
 		return buildDarwinRouteCommands(cidrs, tunAddr, tunGateway)
 	case "windows":
-		return buildWindowsRouteCommands(cidrs, tunGateway)
+		return buildWindowsRouteCommands(cidrs, tunGateway, tunIfIndex)
 	default:
 		return nil, nil, fmt.Errorf("auto route generation does not support os=%s", goos)
 	}
@@ -113,10 +113,16 @@ func buildDarwinRouteCommands(routeCIDRs []string, tunAddr string, tunGateway st
 	return setup, cleanup, nil
 }
 
-func buildWindowsRouteCommands(routeCIDRs []string, tunGateway string) ([]string, []string, error) {
+func buildWindowsRouteCommands(routeCIDRs []string, tunGateway string, tunIfIndex int) ([]string, []string, error) {
 	if strings.TrimSpace(tunGateway) == "" {
 		return nil, nil, fmt.Errorf("tun.gateway is required for windows route generation")
 	}
+
+	addFormat := `route add %s mask %s %s`
+	if tunIfIndex > 0 {
+		addFormat = `route add %s mask %s %s IF %d`
+	}
+
 	setup := make([]string, 0, len(routeCIDRs))
 	cleanup := make([]string, 0, len(routeCIDRs))
 	for _, cidr := range routeCIDRs {
@@ -125,13 +131,25 @@ func buildWindowsRouteCommands(routeCIDRs []string, tunGateway string) ([]string
 		bits := prefix.Bits()
 		if bits == 32 {
 			host := prefix.Addr().String()
-			setup = append(setup, fmt.Sprintf(`route delete %s >NUL 2>NUL & route add %s mask 255.255.255.255 %s`, host, host, tunGateway))
+			addCmd := ""
+			if tunIfIndex > 0 {
+				addCmd = fmt.Sprintf(addFormat, host, "255.255.255.255", tunGateway, tunIfIndex)
+			} else {
+				addCmd = fmt.Sprintf(addFormat, host, "255.255.255.255", tunGateway)
+			}
+			setup = append(setup, fmt.Sprintf(`route delete %s >NUL 2>NUL & %s`, host, addCmd))
 			cleanup = append(cleanup, fmt.Sprintf(`route delete %s >NUL 2>NUL`, host))
 			continue
 		}
 		network := prefix.Addr().String()
 		mask := ipv4MaskFromPrefix(bits)
-		setup = append(setup, fmt.Sprintf(`route delete %s >NUL 2>NUL & route add %s mask %s %s`, network, network, mask, tunGateway))
+		addCmd := ""
+		if tunIfIndex > 0 {
+			addCmd = fmt.Sprintf(addFormat, network, mask, tunGateway, tunIfIndex)
+		} else {
+			addCmd = fmt.Sprintf(addFormat, network, mask, tunGateway)
+		}
+		setup = append(setup, fmt.Sprintf(`route delete %s >NUL 2>NUL & %s`, network, addCmd))
 		cleanup = append(cleanup, fmt.Sprintf(`route delete %s >NUL 2>NUL`, network))
 	}
 	return setup, cleanup, nil

--- a/go/internal/agent/routes_test.go
+++ b/go/internal/agent/routes_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestBuildDarwinRouteCommands_UsesTokenMatchForIface(t *testing.T) {
-	setup, cleanup, err := BuildRouteCommands("darwin", []string{"10.2.2.123/32"}, "10.2.2.2", "10.2.2.1")
+	setup, cleanup, err := BuildRouteCommands("darwin", []string{"10.2.2.123/32"}, "10.2.2.2", "10.2.2.1", 0)
 	if err != nil {
 		t.Fatalf("BuildRouteCommands failed: %v", err)
 	}
@@ -41,5 +41,18 @@ func TestEnsureRouteCommands_ReplacesLegacyDarwinPattern(t *testing.T) {
 	cmd := cfg.Tun.AutoRouteCommands[0]
 	if !strings.Contains(cmd, `$1=="inet" && $2=="10.2.2.2"`) {
 		t.Fatalf("legacy command was not replaced: %s", cmd)
+	}
+}
+
+func TestBuildWindowsRouteCommands_WithInterfaceIndex(t *testing.T) {
+	setup, cleanup, err := BuildRouteCommands("windows", []string{"10.2.2.123/32"}, "", "10.2.2.1", 17)
+	if err != nil {
+		t.Fatalf("BuildRouteCommands failed: %v", err)
+	}
+	if len(setup) != 1 || len(cleanup) != 1 {
+		t.Fatalf("unexpected commands count setup=%d cleanup=%d", len(setup), len(cleanup))
+	}
+	if !strings.Contains(setup[0], "IF 17") {
+		t.Fatalf("windows route command should include interface index, got: %s", setup[0])
 	}
 }


### PR DESCRIPTION
- 将EnsureRouteCommands调用调整至正确位置，确保配置生效
- 优化Windows平台TUN适配器的自动检测，返回包含接口索引的完整信息
- 新增函数fetchWindowsAdapters获取适配器信息，支持接口索引字段
- 根据接口索引构建Windows路由命令，确保路由添加包含接口标识
- 在配置结构体和路由构建函数中新增InterfaceIndex字段支持
- 增加路由命令测试覆盖，验证接口索引参数的正确传递和使用
- 前端改用全局Toast通知替代原msg元素，提升用户反馈体验
- 新增Toast样式与动画，实现消息自动显示和淡出效果
- 移除前端页面无用msg元素，替换为toast容器支持多条信息显示
- 修正前端刷新按钮事件，避免清除提示信息导致用户反馈缺失