### PR TITLE
fix(scripts): 优化 Windows TAP 驱动安装提示和错误处理

### DIFF
--- a/go/scripts/release.ps1
+++ b/go/scripts/release.ps1
@@ -167,7 +167,7 @@ if /i "%PROCESSOR_ARCHITEW6432%"=="AMD64" set "tap_arch=amd64"
 if /i "%PROCESSOR_ARCHITEW6432%"=="ARM64" set "tap_arch=arm64"
 
 if exist ".\drivers\windows\tap.win10\%tap_arch%\devcon.exe" if exist ".\drivers\windows\tap.win10\%tap_arch%\OemVista.inf" (
-  echo Trying bundled TAP package via devcon (arch=%tap_arch%)...
+  echo Trying bundled TAP package via devcon ^(arch=%tap_arch%^)...
   pushd ".\drivers\windows\tap.win10\%tap_arch%"
   .\devcon.exe install .\OemVista.inf tap0901 >NUL 2>NUL
   if not "%errorlevel%"=="0" .\devcon.exe install .\OemVista.inf root\tap0901 >NUL 2>NUL
@@ -178,8 +178,8 @@ if exist ".\drivers\windows\tap.win10\%tap_arch%\devcon.exe" if exist ".\drivers
 )
 
 echo Missing bundled TAP installer assets:
-echo - .\bin\tap-windows-installer.exe (optional)
-echo - .\drivers\windows\tap.win10\%tap_arch%\devcon.exe + OemVista.inf (optional)
+echo - .\bin\tap-windows-installer.exe ^(optional^)
+echo - .\drivers\windows\tap.win10\%tap_arch%\devcon.exe + OemVista.inf ^(optional^)
 echo Please install TAP/Wintun driver, then run again.
 pause
 exit /b 1
@@ -219,7 +219,12 @@ if exist ".\start-ui.cmd" (
 ) else (
   call ".\start-agent.cmd"
 )
-exit /b %errorlevel%
+set "exit_code=%errorlevel%"
+if not "%exit_code%"=="0" (
+  echo Starter failed with code %exit_code%.
+  pause
+)
+exit /b %exit_code%
 '@ | Set-Content -Path (Join-Path $pkgDir "start.cmd") -NoNewline
 
   if ($includeUI -eq "1") {
@@ -300,7 +305,7 @@ if /i "%PROCESSOR_ARCHITEW6432%"=="AMD64" set "tap_arch=amd64"
 if /i "%PROCESSOR_ARCHITEW6432%"=="ARM64" set "tap_arch=arm64"
 
 if exist ".\drivers\windows\tap.win10\%tap_arch%\devcon.exe" if exist ".\drivers\windows\tap.win10\%tap_arch%\OemVista.inf" (
-  echo Trying bundled TAP package via devcon (arch=%tap_arch%)...
+  echo Trying bundled TAP package via devcon ^(arch=%tap_arch%^)...
   pushd ".\drivers\windows\tap.win10\%tap_arch%"
   .\devcon.exe install .\OemVista.inf tap0901 >NUL 2>NUL
   if not "%errorlevel%"=="0" .\devcon.exe install .\OemVista.inf root\tap0901 >NUL 2>NUL
@@ -311,8 +316,8 @@ if exist ".\drivers\windows\tap.win10\%tap_arch%\devcon.exe" if exist ".\drivers
 )
 
 echo Missing bundled TAP installer assets:
-echo - .\bin\tap-windows-installer.exe (optional)
-echo - .\drivers\windows\tap.win10\%tap_arch%\devcon.exe + OemVista.inf (optional)
+echo - .\bin\tap-windows-installer.exe ^(optional^)
+echo - .\drivers\windows\tap.win10\%tap_arch%\devcon.exe + OemVista.inf ^(optional^)
 echo Please install TAP/Wintun driver, then run again.
 pause
 exit /b 1

--- a/go/scripts/release.sh
+++ b/go/scripts/release.sh
@@ -179,7 +179,7 @@ if /i "%PROCESSOR_ARCHITEW6432%"=="AMD64" set "tap_arch=amd64"
 if /i "%PROCESSOR_ARCHITEW6432%"=="ARM64" set "tap_arch=arm64"
 
 if exist ".\drivers\windows\tap.win10\%tap_arch%\devcon.exe" if exist ".\drivers\windows\tap.win10\%tap_arch%\OemVista.inf" (
-  echo Trying bundled TAP package via devcon (arch=%tap_arch%)...
+  echo Trying bundled TAP package via devcon ^(arch=%tap_arch%^)...
   pushd ".\drivers\windows\tap.win10\%tap_arch%"
   .\devcon.exe install .\OemVista.inf tap0901 >NUL 2>NUL
   if not "%errorlevel%"=="0" .\devcon.exe install .\OemVista.inf root\tap0901 >NUL 2>NUL
@@ -190,8 +190,8 @@ if exist ".\drivers\windows\tap.win10\%tap_arch%\devcon.exe" if exist ".\drivers
 )
 
 echo Missing bundled TAP installer assets:
-echo - .\bin\tap-windows-installer.exe (optional)
-echo - .\drivers\windows\tap.win10\%tap_arch%\devcon.exe + OemVista.inf (optional)
+echo - .\bin\tap-windows-installer.exe ^(optional^)
+echo - .\drivers\windows\tap.win10\%tap_arch%\devcon.exe + OemVista.inf ^(optional^)
 echo Please install TAP/Wintun driver, then run again.
 pause
 exit /b 1
@@ -231,7 +231,12 @@ if exist ".\start-ui.cmd" (
 ) else (
   call ".\start-agent.cmd"
 )
-exit /b %errorlevel%
+set "exit_code=%errorlevel%"
+if not "%exit_code%"=="0" (
+  echo Starter failed with code %exit_code%.
+  pause
+)
+exit /b %exit_code%
 CMD
 
   if [[ "${INCLUDE_UI}" == "1" ]]; then
@@ -301,7 +306,7 @@ if /i "%PROCESSOR_ARCHITEW6432%"=="AMD64" set "tap_arch=amd64"
 if /i "%PROCESSOR_ARCHITEW6432%"=="ARM64" set "tap_arch=arm64"
 
 if exist ".\drivers\windows\tap.win10\%tap_arch%\devcon.exe" if exist ".\drivers\windows\tap.win10\%tap_arch%\OemVista.inf" (
-  echo Trying bundled TAP package via devcon (arch=%tap_arch%)...
+  echo Trying bundled TAP package via devcon ^(arch=%tap_arch%^)...
   pushd ".\drivers\windows\tap.win10\%tap_arch%"
   .\devcon.exe install .\OemVista.inf tap0901 >NUL 2>NUL
   if not "%errorlevel%"=="0" .\devcon.exe install .\OemVista.inf root\tap0901 >NUL 2>NUL
@@ -312,8 +317,8 @@ if exist ".\drivers\windows\tap.win10\%tap_arch%\devcon.exe" if exist ".\drivers
 )
 
 echo Missing bundled TAP installer assets:
-echo - .\bin\tap-windows-installer.exe (optional)
-echo - .\drivers\windows\tap.win10\%tap_arch%\devcon.exe + OemVista.inf (optional)
+echo - .\bin\tap-windows-installer.exe ^(optional^)
+echo - .\drivers\windows\tap.win10\%tap_arch%\devcon.exe + OemVista.inf ^(optional^)
 echo Please install TAP/Wintun driver, then run again.
 pause
 exit /b 1


### PR DESCRIPTION
- 转义打印信息中的括号以避免命令行解析错误
- 更新缺失驱动文件提示信息格式，增强可读性
- 在启动命令脚本中添加错误码检查及失败提示
- 保持架构检测及驱动安装逻辑一致性和稳定性
- 应用于 release.ps1、release.sh 与 start.cmd 脚本